### PR TITLE
Fix misnamed Ada project file.

### DIFF
--- a/ada/main.gpr
+++ b/ada/main.gpr
@@ -1,5 +1,5 @@
 with "sdlada";
-with "config/ada_example_config.gpr";
+with "config/main_config.gpr";
 
 project Main is
    for Main use ("main.adb");
@@ -8,7 +8,7 @@ project Main is
    for Exec_Dir use "bin";
 
    package Compiler is
-      for Switches ("ada") use Ada_Example_Config.Ada_Compiler_Switches;
+      for Switches ("ada") use Main_Config.Ada_Compiler_Switches;
    end Compiler;
 
    package Linker is


### PR DESCRIPTION
My first rework changed the name of the main program from Main to Ada_Example. On second thoughts, I reverted to Main, but forgot to clean the directory, so that config/ada_example_config.gpr was still present during tests.

  * ada/main.gpr: config/ada_example_config.gpr changed to config/main_config.gpr. In package Compiler, the Ada_Compiler_Switches now come from Main_Config.