### PR TITLE
Add Linux to the CI workflow for Ada

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - ubuntu-latest
           - macos-latest
+          - windows-latest
     steps:
     -
       name: Checkout


### PR DESCRIPTION
Re-add `ubuntu-latest` to the Ada CI configuration.